### PR TITLE
Improve argument parse behaviour

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,55 @@ void delay(int milliseconds)		/* Delay definition*/
         now = clock();
 }
 
+int open_ps3mca()
+{
+
+  /* Initialise libusb. */
+  res = libusb_init(0);
+  if (res != 0)
+  {
+    fprintf(stderr, "Error initialising libusb.\n");
+    return 1;
+  }
+
+  /* Get the first device with the matching Vendor ID and Product ID. */
+  handle = libusb_open_device_with_vid_pid(0, USB_VENDOR, USB_PRODUCT);
+  if (!handle)
+  {
+    fprintf(stderr, "Unable to open device.\n");
+    fprintf(stderr, "Please verify PS3mca CECHZM1 (SCPH-98042) connection.\n");
+    return 1;
+  }
+
+  /* Check whether a kernel driver is attached to interface #0. If so, we'll 
+   * need to detach it.
+   */
+  if (libusb_kernel_driver_active(handle, 0))
+  {
+    res = libusb_detach_kernel_driver(handle, 0);
+    if (res == 0)
+    {
+      kernelDriverDetached = 1;
+    }
+    else
+    {
+      fprintf(stderr, "Error detaching kernel driver.\n");
+      return 1;
+    }
+  }
+
+  /* Claim interface #0. */
+  res = libusb_claim_interface(handle, 0);
+  if (res != 0)
+  {
+    fprintf(stderr, "Error claiming interface.\n");
+    return 1;
+  }
+
+  return 0;
+
+}
+
 void close_ps3mca()			/* Unmount the ps3mca*/
 {
 
@@ -70,6 +119,12 @@ void close_ps3mca()			/* Unmount the ps3mca*/
 /* --------------------------------------------PS3mca verification of card (PS1 or PS2)---------------------------------------------*/
 int PS3mca_verify_card ()
 {
+
+  if (open_ps3mca() != 0)
+  {
+    return 1;
+  }
+
   uint8_t cmd_card_verification[2];
   uint8_t response_card_verification[2];
 
@@ -147,6 +202,10 @@ int PS3mca_verify_card ()
     fprintf(stderr, "Error receiving message.\n");
   }
 
+  /* Unmount the ps3mca*/
+  close_ps3mca();
+
+  return 0;
 }
 /* -----------------------------------------End of PS3mca verification of card (PS1 or PS2)-----------------------------------------*/
 
@@ -160,6 +219,12 @@ int PS3mca_verify_card ()
 /* -------------------------------------------------------PS1 command get id--------------------------------------------------------*/
 int PS1_get_id ()
 {
+
+  if (open_ps3mca() != 0)
+  {
+    return 1;
+  }
+
   uint8_t cmd_get_id[14];
 
   /* This is the command get id for memory card (SCPH-1020) or PocketStation (SCPH-4000)*/
@@ -339,6 +404,11 @@ int PS1_get_id ()
     fprintf(stderr, "Error receiving message.\n");
   }
 
+  /* Unmount the ps3mca*/
+  close_ps3mca();
+
+  return 0;
+
 }
 /* ----------------------------------------------------End of PS1 command get id----------------------------------------------------*/
 
@@ -350,6 +420,12 @@ int PS1_get_id ()
 /* ---------------------------------------------------PocketStation command get id--------------------------------------------------*/
 int PocketStation_get_id ()
 {
+
+  if (open_ps3mca() != 0)
+  {
+    return 1;
+  }
+
   uint8_t cmd_get_id_pkst[9];
 
   /* This is the command get id for PocketStation (SCPH-4000)*/
@@ -513,6 +589,11 @@ int PocketStation_get_id ()
     fprintf(stderr, "Error receiving message.\n");
   }
 
+  /* Unmount the ps3mca*/
+  close_ps3mca();
+
+  return 0;
+
 }
 /* ------------------------------------------------End of PocketStation command get id----------------------------------------------*/
 
@@ -551,6 +632,12 @@ int PocketStation_get_id ()
 */
 int PocketStation_get_dir_date ()
 {
+
+  if (open_ps3mca() != 0)
+  {
+    return 1;
+  }
+
   uint8_t cmd_get_dir_date_pkst[25];
 
   /* This is the command get id for PocketStation (SCPH-4000)*/
@@ -856,6 +943,11 @@ int PocketStation_get_dir_date ()
     fprintf(stderr, "Error receiving message.\n");
   }
 
+  /* Unmount the ps3mca*/
+  close_ps3mca();
+
+  return 0;
+
 }
 /* ------------------------------End of PocketStation command get Dir_index, ComFlags, F_SN, Date, and Time-------------------------*/
 
@@ -886,6 +978,12 @@ int PocketStation_get_dir_date ()
 */
 int PS1_read ()
 {
+
+  if (open_ps3mca() != 0)
+  {
+    return 1;
+  }
+
   uint8_t cmd_read[144];
   FILE *output=fopen( "Readed_memory_card.mcd", "wb" );	/* Open and create a binary file output in writing*/
 
@@ -1076,6 +1174,11 @@ int PS1_read ()
   fflush(output);
   fclose(output);
 
+  /* Unmount the ps3mca*/
+  close_ps3mca();
+
+  return 0;
+
 }
 /* ----------------------------------------------------End of PS1 command read------------------------------------------------------*/
 
@@ -1104,6 +1207,12 @@ int PS1_read ()
 */
 int PS1_write ()
 {
+
+  if (open_ps3mca() != 0)
+  {
+    return 1;
+  }
+
   uint8_t cmd_write[142];
   FILE *input=fopen( "write.mcd", "rb" );		/* Open write.mcd in reading*/
 
@@ -1263,6 +1372,11 @@ int PS1_write ()
   fflush(input);
   fclose(input);
 
+  /* Unmount the ps3mca*/
+  close_ps3mca();
+
+  return 0;
+
 }
 /* ----------------------------------------------------End of PS1 command write------------------------------------------------------*/
 
@@ -1277,91 +1391,54 @@ int PS1_write ()
 /*-----------------------------------------------------------Main program-----------------------------------------------------------*/
 int main(int argc, char*argv[])
 {
-  /* Initialise libusb. */
-  res = libusb_init(0);
-  if (res != 0)
+
+  if (argc > 2)
   {
-    fprintf(stderr, "Error initialising libusb.\n");
-    return 1;
+    fprintf(stderr, "Warning: %s only processes one option at a time! %d were given.\n", argv[0], argc - 1);
   }
 
-  /* Get the first device with the matching Vendor ID and Product ID. */
-  handle = libusb_open_device_with_vid_pid(0, USB_VENDOR, USB_PRODUCT);
-  if (!handle)
+  if (argc < 2)
   {
-    fprintf(stderr, "Unable to open device.\n");
-    fprintf(stderr, "Please verify PS3mca CECHZM1 (SCPH-98042) connection.\n");
+    fprintf(stderr, "No options given!\n");
     return 1;
   }
-
-  /* Check whether a kernel driver is attached to interface #0. If so, we'll 
-   * need to detach it.
-   */
-  if (libusb_kernel_driver_active(handle, 0))
+  else
   {
-    res = libusb_detach_kernel_driver(handle, 0);
-    if (res == 0)
+    /* Switch-case argv*/
+    switch (*argv[1])  
     {
-      kernelDriverDetached = 1;
+      default:
+        fprintf(stderr, "Unknown option %s\n", argv[1]);
+        break;
+
+      case 'v':
+        return PS3mca_verify_card ();
+        break;
+
+      case 's':
+        return PS1_get_id ();
+        break;
+
+      case 'r':
+        return PS1_read ();
+        break;
+
+      case 'w':
+        return PS1_write ();
+        break;
+
+      case 'x':
+        return PocketStation_get_id ();
+        break;
+
+      case 'z':
+        return PocketStation_get_dir_date ();
+        break;
     }
-    else
-    {
-      fprintf(stderr, "Error detaching kernel driver.\n");
-      return 1;
-    }
   }
 
-  /* Claim interface #0. */
-  res = libusb_claim_interface(handle, 0);
-  if (res != 0)
-  {
-    fprintf(stderr, "Error claiming interface.\n");
-    return 1;
-  }
+  return 1;
 
-
-  /* Switch-case argv*/
-  while (++(*argv))
-  {
-	if ( **argv == '-' )
-	{
-            switch (*argv[1])  
-            {
-		default:
-		fprintf(stderr, "Unknown option %c\n", (*argv)[1]);
-		break;
-
-		case 'v':
-		return PS3mca_verify_card ();
-		break;
-
-		case 's':
-		return PS1_get_id ();
-		break;
-
-		case 'r':
-		return PS1_read ();
-		break;
-
-		case 'w':
-		return PS1_write ();
-		break;
-
-		case 'x':
-		return PocketStation_get_id ();
-		break;
-
-		case 'z':
-		return PocketStation_get_dir_date ();
-		break;
-            }
-	}
-  }
-
-  /* Unmount the ps3mca*/
-  close_ps3mca();
-
-  return 0;
 }
 /*--------------------------------------------------------End of Main program-------------------------------------------------------*/
 


### PR DESCRIPTION
This patch fixes some undefined behaviour in the argument parser. Previously, it was possible for the application to encounter a segmentation fault due to the `*argv` pointer floating into invalid memory. It also avoids segmentation faults from passing zero arguments.

The parser has been simplified to accept a single operation per program invocation, and as a consequence it no longer plays with pointer incrementation to operate!

I also shifted the ps3mca initialisation code into a function (mirroring `close_ps3mca`) and made it the responsibility of each individual operation's function to call it, and `close_ps3mca`. This means you don't have to wait for the ps3mca to be initialised (possibly failing in the process!) in order to get output from the argument parser.