### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CFLAGS ?= $(shell pkg-config --cflags libusb-1.0)
 LDFLAGS ?= $(shell pkg-config --libs libusb-1.0)
 
 ps3mca-ps1:
-	$(CC) $(CFLAGS) $(LDFLAGS) src/main.c -o ps3mca-ps1
-	$(CC) $(CFLAGS) $(LDFLAGS) -D DEBUG src/main.c -o ps3mca-ps1-debug
+	$(CC) src/main.c -o ps3mca-ps1 $(CFLAGS) $(LDFLAGS)
+	$(CC) -D DEBUG src/main.c -o ps3mca-ps1-debug $(CFLAGS) $(LDFLAGS) 
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
(Sorry, ignore the other closed PR that looks just like this - I opened that from the wrong account.)

For whatever reason, I get this error trying to compile the project on Ubuntu 20.04:
```
cc -I/usr/include/libusb-1.0 -lusb-1.0 src/main.c -o ps3mca-ps1
src/main.c: In function ‘main’:
src/main.c:1054:42: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘int’ [-Wformat=]
 1054 |         fprintf(stderr, "Unknown option %s\n", argv[1][0]);
      |                                         ~^     ~~~~~~~~~~
      |                                          |            |
      |                                          char *       int
      |                                         %d
/usr/bin/ld: /tmp/cc6HIKrF.o: in function `open_ps3mca':
main.c:(.text+0x5b): undefined reference to `libusb_init'
/usr/bin/ld: main.c:(.text+0xb5): undefined reference to `libusb_open_device_with_vid_pid'
/usr/bin/ld: main.c:(.text+0x126): undefined reference to `libusb_kernel_driver_active'
/usr/bin/ld: main.c:(.text+0x13e): undefined reference to `libusb_detach_kernel_driver'
/usr/bin/ld: main.c:(.text+0x195): undefined reference to `libusb_claim_interface'
/usr/bin/ld: /tmp/cc6HIKrF.o: in function `close_ps3mca':
main.c:(.text+0x1ef): undefined reference to `libusb_release_interface'
/usr/bin/ld: main.c:(.text+0x23d): undefined reference to `libusb_attach_kernel_driver'
/usr/bin/ld: main.c:(.text+0x247): undefined reference to `libusb_exit'
/usr/bin/ld: /tmp/cc6HIKrF.o: in function `PS3mca_verify_card':
main.c:(.text+0x2d9): undefined reference to `libusb_bulk_transfer'
/usr/bin/ld: main.c:(.text+0x35f): undefined reference to `libusb_bulk_transfer'
/usr/bin/ld: /tmp/cc6HIKrF.o: in function `PS1_get_id':
main.c:(.text+0x547): undefined reference to `libusb_bulk_transfer'
/usr/bin/ld: main.c:(.text+0x5d0): undefined reference to `libusb_bulk_transfer'
/usr/bin/ld: /tmp/cc6HIKrF.o: in function `PS1_read':
main.c:(.text+0x9e8): undefined reference to `libusb_bulk_transfer'
/usr/bin/ld: /tmp/cc6HIKrF.o:main.c:(.text+0xa63): more undefined references to `libusb_bulk_transfer' follow
collect2: error: ld returned 1 exit status
make: *** [Makefile:6: ps3mca-ps1] Error 1
```

Moving CFLAGS and LDFLAGS around to the end of the compile statements seems to fix this.