### PR TITLE
Fix Option Error Format String

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ CC ?= gcc
 CFLAGS ?= $(shell pkg-config --cflags libusb-1.0)
 LDFLAGS ?= $(shell pkg-config --libs libusb-1.0)
 
-ps3mca-ps1:
+ps3mca-ps1: src/main.c
 	$(CC) src/main.c -o ps3mca-ps1 $(CFLAGS) $(LDFLAGS)
-	$(CC) -D DEBUG src/main.c -o ps3mca-ps1-debug $(CFLAGS) $(LDFLAGS) 
+	$(CC) -D DEBUG src/main.c -o ps3mca-ps1-debug $(CFLAGS) $(LDFLAGS)
 
 .PHONY: clean
 clean:

--- a/src/main.c
+++ b/src/main.c
@@ -1051,7 +1051,7 @@ int main(int argc, char* argv[])
     switch (argv[1][0])  
     {
       default:
-        fprintf(stderr, "Unknown option %s\n", argv[1][0]);
+        fprintf(stderr, "Unknown option %c\n", argv[1][0]);
         break;
 
       case 'v':


### PR DESCRIPTION
Replaces the string specifier (`%s`) with the char specifier (`%c`) to fix a segfault when an invalid option was selected.

Also adds `src/main.c` as a dependency of the `ps3mca-ps1` target so that `make` will rebuild when the source has changed.